### PR TITLE
Migrate from Commons Lang 2 to Commons Lang 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,10 @@
   
   <dependencies>
     <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-lang3-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>dashboard-view</artifactId>
       <optional>true</optional>

--- a/src/main/java/org/jenkinsci/plugins/vmanager/InvokeExecutionTask.java
+++ b/src/main/java/org/jenkinsci/plugins/vmanager/InvokeExecutionTask.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import jenkins.MasterToSlaveFileCallable;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 /**
  *
@@ -123,7 +123,7 @@ public class InvokeExecutionTask extends  MasterToSlaveFileCallable<Void> implem
                         jobListener.getLogger().println(" " + ste);
                     }
 
-                    jobListener.getLogger().println(ExceptionUtils.getFullStackTrace(e));
+                    jobListener.getLogger().println(ExceptionUtils.getStackTrace(e));
                 }
                 catch (InterruptedException ex) {
                         jobListener.getLogger().println(ex.getMessage());
@@ -131,7 +131,7 @@ public class InvokeExecutionTask extends  MasterToSlaveFileCallable<Void> implem
                             jobListener.getLogger().println(" " + ste);
                         }
 
-                        jobListener.getLogger().println(ExceptionUtils.getFullStackTrace(ex));
+                        jobListener.getLogger().println(ExceptionUtils.getStackTrace(ex));
                     } finally { 
                         if (in != null){
                             in.close();

--- a/src/main/java/org/jenkinsci/plugins/vmanager/LaunchHolder.java
+++ b/src/main/java/org/jenkinsci/plugins/vmanager/LaunchHolder.java
@@ -22,7 +22,7 @@ import java.util.logging.Logger;
 
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 public class LaunchHolder {
 
@@ -132,7 +132,7 @@ public class LaunchHolder {
                         abortVManagerSessions(logger, url, requireAuth, user, password, listener, dynamicUserId, buildNumber, workPlacePath, buildID, connConnTimeOut, connReadTimeout, advConfig, notInTestMode, listOfSessions, workingJobDir);
                     } catch (Exception ex) {
                         listener.getLogger().print("Failed to delete session during build removal." + ex.getMessage());
-                        listener.getLogger().println(ExceptionUtils.getFullStackTrace(ex));
+                        listener.getLogger().println(ExceptionUtils.getStackTrace(ex));
                     }
                 }
 

--- a/src/main/java/org/jenkinsci/plugins/vmanager/Utils.java
+++ b/src/main/java/org/jenkinsci/plugins/vmanager/Utils.java
@@ -37,8 +37,8 @@ import javax.net.ssl.*;
 import org.apache.commons.codec.binary.Base64;
 
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 public class Utils {
 
@@ -1456,14 +1456,14 @@ public class Utils {
                 jobListener.getLogger().println(" " + ste);
             }
 
-            jobListener.getLogger().println(ExceptionUtils.getFullStackTrace(e));
+            jobListener.getLogger().println(ExceptionUtils.getStackTrace(e));
         } catch (InterruptedException ex) {
             jobListener.getLogger().println(ex.getMessage());
             for (StackTraceElement ste : ex.getStackTrace()) {
                 jobListener.getLogger().println(" " + ste);
             }
 
-            jobListener.getLogger().println(ExceptionUtils.getFullStackTrace(ex));
+            jobListener.getLogger().println(ExceptionUtils.getStackTrace(ex));
         } finally {
             if (inError != null){
                 inError.close();

--- a/src/main/java/org/jenkinsci/plugins/vmanager/VMGRLaunch.java
+++ b/src/main/java/org/jenkinsci/plugins/vmanager/VMGRLaunch.java
@@ -31,8 +31,8 @@ import jakarta.servlet.ServletException;
 import jenkins.model.Jenkins;
 
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 import org.kohsuke.stapler.AncestorInPath;
 
@@ -871,7 +871,7 @@ public class VMGRLaunch extends Builder {
                 listener.getLogger().println(" " + ste);
             }
 
-            listener.getLogger().println(ExceptionUtils.getFullStackTrace(e));
+            listener.getLogger().println(ExceptionUtils.getStackTrace(e));
 
             return false;
         }

--- a/src/main/java/org/jenkinsci/plugins/vmanager/dsl/post/DSLPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/vmanager/dsl/post/DSLPublisher.java
@@ -34,7 +34,7 @@ import java.util.Iterator;
 import java.util.List;
 import jakarta.servlet.ServletException;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.vmanager.SummaryReportParams;
 import org.jenkinsci.plugins.vmanager.Utils;
 import org.jenkinsci.plugins.vmanager.VAPIConnectionParam;


### PR DESCRIPTION
Migrate from deprecated/EOL Commons Lang 2 to Commons Lang 3.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

## What's changed

- Renamed the `org.apache.commons.lang.*` imports to `org.apache.commons.lang3.*` and declared
  `io.jenkins.plugins:commons-lang3-api`.
- `ExceptionUtils.getFullStackTrace(..)` becomes `getStackTrace(..)` — Lang 3 renamed it.

`normalizeSpace`, `split` and `isBlank` behave identically in Lang 3.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.

The `ban-commons-lang-2` enforcer rule was left disabled: it needs parent POM `6.2116.v7501b_67dc517` or newer and this plugin is on `5.6`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact @timja.
